### PR TITLE
Add traditional link styles to all links except headers, and project repos

### DIFF
--- a/islands/Footer.tsx
+++ b/islands/Footer.tsx
@@ -9,7 +9,7 @@ export const Footer = () => {
       <hr class="mx-auto my-8 max-w-md"/>
       <div class="text-center">
         <span class="inline-block">
-          <a href="https://github.com/devict/help" target="_blank" rel="noopener noreferrer" class="text-md font-medium">
+          <a href="https://github.com/devict/help" target="_blank" rel="noopener noreferrer" class="text-md font-medium underline text-blue-600 hover:text-blue-800 visited:text-purple-600">
             <span class="flex items-center gap-1">
               Github
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="w-6 h-6">

--- a/routes/_404.tsx
+++ b/routes/_404.tsx
@@ -12,7 +12,7 @@ export default function Error404() {
           <p class="my-4">
             The page you were looking for doesn't exist.
           </p>
-          <a href="/" class="underline">Go back home</a>
+          <a href="/" class="underline text-blue-600 hover:text-blue-800 visited:text-purple-600">Go back home</a>
         </div>
       </div>
     </>

--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -55,7 +55,7 @@ export default function Home() {
             content: (
               <>
                 Join us{" "}
-                <a href="https://slack.devict.org" title="Join devICT Slack">
+                <a href="https://slack.devict.org" title="Join devICT Slack" class="underline text-blue-600 hover:text-blue-800 visited:text-purple-600">
                   in Slack
                 </a>{" "}
                 and jump into the conversation! Share what you're working on,
@@ -70,7 +70,7 @@ export default function Home() {
             content: (
               <>
                 Browse our{" "}
-                <a href="/projects" title="devICT Projects">active projects</a>,
+                <a href="/projects" title="devICT Projects" class="underline text-blue-600 hover:text-blue-800 visited:text-purple-600">active projects</a>,
                 find an issue that interests you, and jump right in!
               </>
             ),
@@ -83,7 +83,7 @@ export default function Home() {
               <>
                 Help us with documentation, design, or outreach efforts. Add
                 clarity by asking questions on{" "}
-                <a href="/projects" title="devICT Projects">existing issues</a>,
+                <a href="/projects" title="devICT Projects" class="underline text-blue-600 hover:text-blue-800 visited:text-purple-600">existing issues</a>,
                 or contribute your ideas by filing new ones.
               </>
             ),

--- a/routes/projects.tsx
+++ b/routes/projects.tsx
@@ -31,11 +31,11 @@ export default async function Home() {
           const repoUrl = `https://github.com/${repoPath}`;
           return (
             <li class="my-1">
-              <span class="font-bold">
+              <span class="font-bold underline hover:text-gray-600">
                 <a href={repoUrl}>{repoPath}</a>:{" "}
               </span>
               <span>
-                <a href={issue.html_url}>{issue.title}</a>
+                <a href={issue.html_url} class="underline text-blue-600 hover:text-blue-800 visited:text-purple-600">{issue.title}</a>
               </span>
             </li>
           );


### PR DESCRIPTION
Fixes #5 

Added traditional link styles to all links except header, and the project repos, as they already had some styles applied. Did add a couple of tweaks (underline, hover color) to the project repo links.